### PR TITLE
Fix excessive scope of css block

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@
     position: absolute;
 }
 
-.output-html{
+#script_twoshot_tabs .output-html{
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
.output-html changes affected other blocks (notably the extra networks subdirectories, placing them horizontal to the contents with center vertical alignment instead of on top and making it hard to use when a lot of items are present)